### PR TITLE
Settings: Move SIM restrictions currently applied to per-app data usage

### DIFF
--- a/res/xml/app_data_usage.xml
+++ b/res/xml/app_data_usage.xml
@@ -51,7 +51,6 @@
 
     <PreferenceCategory
         android:key="app_data_usage_settings_category"
-        settings:isPreferenceVisible="@bool/config_show_sim_info"
         android:layout="@layout/preference_category_no_label">
 
         <Preference
@@ -71,12 +70,14 @@
         <com.android.settingslib.RestrictedSwitchPreference
             android:key="restrict_cellular"
             android:title="@string/data_usage_app_restrict_mobile"
-            android:summary="@string/data_usage_app_restrict_mobile_summary" />
+            android:summary="@string/data_usage_app_restrict_mobile_summary"
+            settings:isPreferenceVisible="@bool/config_show_sim_info" />
 
         <com.android.settingslib.RestrictedSwitchPreference
             android:key="restrict_background"
             android:title="@string/data_usage_app_restrict_background"
             android:summary="@string/data_usage_app_restrict_background_summary"
+            settings:isPreferenceVisible="@bool/config_show_sim_info"
             settings:useAdditionalSummary="true"
             settings:restrictedSwitchSummary="@string/disabled_by_admin" />
 
@@ -89,6 +90,7 @@
             android:key="unrestricted_data_saver"
             android:title="@string/unrestricted_app_title"
             android:summary="@string/unrestricted_app_summary"
+            settings:isPreferenceVisible="@bool/config_show_sim_info"
             settings:useAdditionalSummary="true"
             settings:restrictedSwitchSummary="@string/disabled_by_admin" />
 

--- a/src/com/android/settings/datausage/AppDataUsage.java
+++ b/src/com/android/settings/datausage/AppDataUsage.java
@@ -125,10 +125,6 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     private long mSelectedCycle;
     private boolean mIsLoading;
 
-    public boolean isSimHardwareVisible(Context context) {
-        return SubscriptionUtil.isSimHardwareVisible(context);
-    }
-
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
@@ -181,7 +177,7 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
         final UidDetailProvider uidDetailProvider = getUidDetailProvider();
 
         if (mAppItem.key > 0) {
-            if ((!isSimHardwareVisible(mContext)) || !UserHandle.isApp(mAppItem.key)) {
+            if (!UserHandle.isApp(mAppItem.key)) {
                 final UidDetail uidDetail = uidDetailProvider.getUidDetail(mAppItem.key, true);
                 mIcon = uidDetail.icon;
                 mLabel = uidDetail.label;
@@ -384,9 +380,6 @@ public class AppDataUsage extends DataUsageBaseFragment implements OnPreferenceC
     private void updatePrefs(boolean restrictBackground, boolean unrestrictData,
             boolean restrictAll, boolean restrictCellular, boolean restrictVpn,
             boolean restrictWifi, boolean hasInternetPermission) {
-        if (!isSimHardwareVisible(mContext)) {
-            return;
-        }
         setBackPreferenceListAnimatorIfLoaded();
         final EnforcedAdmin admin = RestrictedLockUtilsInternal.checkIfMeteredDataRestricted(
                 mContext, mPackageName, UserHandle.getUserId(mAppItem.key));


### PR DESCRIPTION
When Google introduced commit d3b35f2, all the custom addons for per-app network isolation became hidden on devices that set the overlay config_show_sim_info to "false".

Expose only the toggles that really make sense, i.e. for the mentioned usecase, leave the main toggle (restrict all), WiFi and VPN data toggles.

Change-Id: I4720483d98ae69fbb6eec8fa749e8d071e91c629