### PR TITLE
Settings: Hide Flashlight

### DIFF
--- a/src/com/android/settings/flashlight/FlashlightHandleActivity.java
+++ b/src/com/android/settings/flashlight/FlashlightHandleActivity.java
@@ -82,10 +82,7 @@ public class FlashlightHandleActivity extends Activity implements Indexable {
                 @Override
                 public List<String> getNonIndexableKeys(Context context) {
                     List<String> keys = super.getNonIndexableKeys(context);
-                    if (!FlashlightSlice.isFlashlightAvailable(context)) {
-                        Log.i(TAG, "Flashlight is unavailable");
-                        keys.add(DATA_KEY);
-                    }
+                    keys.add(DATA_KEY);
                     return keys;
                 }
             };


### PR DESCRIPTION
* Class comment states: "Headless activity that toggles flashlight state when launched."
* Comment in constructor states: "The sole purpose of this activity is to provide a place to index flashlight into Settings search."
* Since it does only the second thing successfully and we do neither know why we need a useless search result nor does it server any purpose, hide it from search results
* We could remove the whole class, but since it's from AOSP I decided to keep the change footprint minimal

Test: Type "Flashlight" into settings search - result does not appear anymore
Fixes: https://gitlab.com/LineageOS/issues/android/-/issues/6397

Change-Id: I53541c700e24efd33d386c38a4ea38fb1b8b81d6